### PR TITLE
Set app metadata and lock down Android permissions for v1.0.0 release

### DIFF
--- a/app.json
+++ b/app.json
@@ -22,7 +22,8 @@
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"
       },
-      "edgeToEdgeEnabled": true
+      "edgeToEdgeEnabled": true,
+      "permissions": []
     },
     "web": {
       "favicon": "./assets/favicon.png"


### PR DESCRIPTION
This PR finalizes app configuration for the v1.0.0 release of the Speech Timer app.

Changes include:
- Set app name to "Speech Timer"
- Defined iOS bundleIdentifier: com.karkya.speechtimer
- Defined Android package: com.karkya.speechtimer
- Version set to 1.0.0
- Explicitly locked down Android permissions to an empty array (`"permissions": []`) to ensure minimal access and a clean Play Store privacy declaration

These changes ensure compliance with App Store and Play Store requirements and reflect the app's public branding under the Karkya identity.
