### PR TITLE
Fix: calculate and log accurate elapsed time on pause

### DIFF
--- a/__tests__/useTimer.test.ts
+++ b/__tests__/useTimer.test.ts
@@ -33,7 +33,6 @@ describe('useTimer', () => {
       result.current.toggle(); // start
     });
 
-    // Simulate 5 seconds
     act(() => {
       jest.advanceTimersByTime(5000);
     });
@@ -44,37 +43,43 @@ describe('useTimer', () => {
 
   it('pauses correctly and logs pause', () => {
     const { result } = renderHook(() => useTimer(config, mockLogger));
-
+  
     act(() => {
       result.current.toggle(); // start
-      jest.advanceTimersByTime(3000);
+      jest.advanceTimersByTime(3000); // simulate 3s
       result.current.toggle(); // pause
     });
-
+  
+    // Force state updates to flush
+    act(() => {
+      // simulate time to flush the internal setState
+      jest.advanceTimersByTime(1);
+    });
+  
     expect(result.current.state.isRunning).toBe(false);
     expect(result.current.state.elapsedSeconds).toBe(3);
     expect(mockLogger.event).toHaveBeenCalledWith('pause', { elapsed: 3 });
-  });
+  });   
 
   it('resets and logs reset', () => {
     const { result } = renderHook(() => useTimer(config, mockLogger));
-  
+
     act(() => {
       result.current.toggle(); // start
     });
-  
+
     act(() => {
-      jest.advanceTimersByTime(3900);     // ⏱ simulate 4 seconds
-      jest.runOnlyPendingTimers();        // ✅ flush any timer callbacks
-      result.current.reset();             // 🔁 now safely call reset
+      jest.advanceTimersByTime(3900);     // simulate 3.9s
+      jest.runOnlyPendingTimers();        // flush 3 ticks
+      result.current.reset();             // call reset before 4th tick
     });
-  
+
     expect(result.current.state.elapsedSeconds).toBe(0);
     expect(result.current.state.isRunning).toBe(false);
-  
+
     expect(mockLogger.event).toHaveBeenCalledWith('reset', {
       elapsed: 4,
       name: config.name,
     });
-  });  
+  });
 });

--- a/src/hooks/useTimer.ts
+++ b/src/hooks/useTimer.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { TimerConfig, TimerController } from '../types/timerTypes';
+import { Severity, TimerConfig } from '../types/timerTypes';
 import { getCurrentSeverity } from '../utils/getCurrentSeverity';
 import { Logger } from '../logger/Logger';
 import { ConsoleLogger } from '../logger/ConsoleLogger';
@@ -12,6 +12,7 @@ export function useTimer(config: TimerConfig, logger: Logger = ConsoleLogger): T
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
   const startTimestamp = useRef<number | null>(null);
   const pausedOffset = useRef(0);
+  const isRunningRef = useRef(false); // ✅ source of truth
 
   const tick = () => {
     if (startTimestamp.current === null) return;
@@ -20,39 +21,55 @@ export function useTimer(config: TimerConfig, logger: Logger = ConsoleLogger): T
     setElapsedSeconds(delta);
   };
 
+  const start = () => {
+    startTimestamp.current = Date.now();
+    intervalRef.current = setInterval(tick, 1000);
+    isRunningRef.current = true;       // ✅ sync ref
+    setIsRunning(true);
+    logger.event('start', { name: config.name, startTime: startTimestamp.current });
+  };
+
+  const pause = () => {
+    if (!isRunningRef.current || !startTimestamp.current) return;
+  
+    const now = Date.now();
+  
+    // calculate elapsed before mutating startTimestamp
+    const elapsedAtPause = Math.floor((now - startTimestamp.current + pausedOffset.current) / 1000);
+  
+    pausedOffset.current += now - startTimestamp.current;
+    clearInterval(intervalRef.current!);
+    intervalRef.current = null;
+    startTimestamp.current = null;
+    isRunningRef.current = false;
+    setIsRunning(false);
+  
+    logger.event('pause', { elapsed: elapsedAtPause });
+  };
+
   const toggle = () => {
-    if (isRunning) {
-      // Pause
-      if (startTimestamp.current) {
-        pausedOffset.current += Date.now() - startTimestamp.current;
-      }
-      clearInterval(intervalRef.current!);
-      intervalRef.current = null;
-      startTimestamp.current = null;
-      setIsRunning(false);
-      logger.event('pause', { elapsed: elapsedSeconds });
-    } else {
-      // Start
-      startTimestamp.current = Date.now();
-      intervalRef.current = setInterval(tick, 1000);
-      setIsRunning(true);
-      logger.event('start', { name: config.name, startTime: startTimestamp.current });
-    }
+    isRunningRef.current ? pause() : start(); // ✅ use ref, not possibly stale state
   };
 
   const reset = () => {
     const now = Date.now();
     const elapsedAtReset = startTimestamp.current
-      ? Math.floor((now - startTimestamp.current) / 1000)
-      : 0;
+      ? Math.floor((now - startTimestamp.current + pausedOffset.current) / 1000)
+      : elapsedSeconds;
+
     clearInterval(intervalRef.current!);
     intervalRef.current = null;
     pausedOffset.current = 0;
     startTimestamp.current = null;
+    isRunningRef.current = false;
     setElapsedSeconds(0);
     setIsRunning(false);
     setLastSeverity('gray');
-    logger.event('reset', { elapsed: elapsedAtReset, name: config.name });
+
+    logger.event('reset', {
+      elapsed: elapsedAtReset,
+      name: config.name,
+    });
   };
 
   const currentSeverity = getCurrentSeverity(config.warnings, elapsedSeconds);
@@ -60,14 +77,20 @@ export function useTimer(config: TimerConfig, logger: Logger = ConsoleLogger): T
   useEffect(() => {
     if (currentSeverity !== lastSeverity) {
       setLastSeverity(currentSeverity);
-      logger.event('thresholdCross', { severity: currentSeverity, time: elapsedSeconds });
+      logger.event('thresholdCross', {
+        severity: currentSeverity,
+        time: elapsedSeconds,
+      });
     }
   }, [currentSeverity]);
 
   useEffect(() => {
     return () => {
-      if (isRunning) {
-        logger.event('interrupted', { elapsed: elapsedSeconds, reason: 'unmount' });
+      if (isRunningRef.current) {
+        logger.event('interrupted', {
+          elapsed: elapsedSeconds,
+          reason: 'unmount',
+        });
       }
       clearInterval(intervalRef.current!);
     };
@@ -82,6 +105,20 @@ export function useTimer(config: TimerConfig, logger: Logger = ConsoleLogger): T
       currentSeverity,
     },
     toggle,
+    pause, // This should now match the updated TimerController type
     reset,
   };
 }
+
+type TimerController = {
+  config: TimerConfig;
+  state: {
+    isRunning: boolean;
+    elapsedSeconds: number;
+    startTimestamp: number | null;
+    currentSeverity: Severity;
+  };
+  toggle: () => void;
+  reset: () => void;
+  pause: () => void; // Add this line
+};


### PR DESCRIPTION
Fixes Issue #18 by ensuring the pause event logs the correct elapsed time.

- Calculates `elapsedAtPause` using timestamp math before nulling state
- Avoids stale React state (`elapsedSeconds`) which may lag by 1 tick
- Adds clean, consistent logic using a single `now = Date.now()` reference
- Confirmed with passing unit tests for pause, reset, and toggle

This makes the hook more robust and the logs more accurate in both production and tests.
